### PR TITLE
Fix antialiasing level being too high

### DIFF
--- a/nocturne/cpp/include/canvas.h
+++ b/nocturne/cpp/include/canvas.h
@@ -16,7 +16,7 @@ class Canvas : public sf::RenderTexture {
          sf::Color background_color = sf::Color(50, 50, 50))
       : height_(height), width_(width) {
     sf::ContextSettings texture_settings;
-    texture_settings.antialiasingLevel = 4;
+    texture_settings.antialiasingLevel = std::min(sf::RenderTexture::getMaximumAntialiasingLevel(), 4);
     create(width, height, texture_settings);
     clear(background_color);
   }

--- a/nocturne/cpp/include/canvas.h
+++ b/nocturne/cpp/include/canvas.h
@@ -16,7 +16,7 @@ class Canvas : public sf::RenderTexture {
          sf::Color background_color = sf::Color(50, 50, 50))
       : height_(height), width_(width) {
     sf::ContextSettings texture_settings;
-    texture_settings.antialiasingLevel = std::min(sf::RenderTexture::getMaximumAntialiasingLevel(), 4);
+    texture_settings.antialiasingLevel = std::min(sf::RenderTexture::getMaximumAntialiasingLevel(), 4u);
     create(width, height, texture_settings);
     clear(background_color);
   }

--- a/nocturne/cpp/src/simulation.cc
+++ b/nocturne/cpp/src/simulation.cc
@@ -14,7 +14,7 @@ void Simulation::Render() {
     constexpr int64_t kWinHeight = 800;
 
     sf::ContextSettings settings;
-    settings.antialiasingLevel = std::min(sf::RenderTexture::getMaximumAntialiasingLevel(), 4);
+    settings.antialiasingLevel = std::min(sf::RenderTexture::getMaximumAntialiasingLevel(), 4u);
     render_window_ = std::make_unique<sf::RenderWindow>(
         sf::VideoMode(kWinWidth, kWinHeight), "Nocturne", sf::Style::Default,
         settings);

--- a/nocturne/cpp/src/simulation.cc
+++ b/nocturne/cpp/src/simulation.cc
@@ -14,7 +14,7 @@ void Simulation::Render() {
     constexpr int64_t kWinHeight = 800;
 
     sf::ContextSettings settings;
-    settings.antialiasingLevel = 1;
+    settings.antialiasingLevel = std::min(sf::RenderTexture::getMaximumAntialiasingLevel(), 4);
     render_window_ = std::make_unique<sf::RenderWindow>(
         sf::VideoMode(kWinWidth, kWinHeight), "Nocturne", sf::Style::Default,
         settings);


### PR DESCRIPTION
Solve errors such as `Impossible to create render texture (unsupported anti-aliasing level) Requested: 4 Maximum supported: 1.`

Maximum 4 since it can slow down performances.