### PR TITLE
Fix a bug for RangeTree2d when the input size is 2^n

### DIFF
--- a/nocturne/cpp/include/geometry/range_tree_2d.h
+++ b/nocturne/cpp/include/geometry/range_tree_2d.h
@@ -121,7 +121,7 @@ class RangeTree2d {
     std::sort(
         points_.begin(), points_.end(),
         [](const PointLike* a, const PointLike* b) { return a->X() < b->X(); });
-    for (capacity_ = 1; capacity_ < size_; capacity_ <<= 1)
+    for (capacity_ = 1; capacity_ <= size_; capacity_ <<= 1)
       ;
     nodes_.assign(2 * capacity_, std::vector<const PointLike*>());
     for (int64_t i = 0; i < size_; ++i) {


### PR DESCRIPTION
When the input size is exactly 2^n, there will some issues in the previous RangeTree2d.
The impact of this bug should be limited since the probability of having exactly 2^n road points should be pretty low.