### PR TITLE
Improve space usage of RangeTree2d

### DIFF
--- a/nocturne/cpp/tests/src/geometry/range_tree_2d_test.cc
+++ b/nocturne/cpp/tests/src/geometry/range_tree_2d_test.cc
@@ -57,14 +57,12 @@ std::vector<const MockPoint*> RangeSearch(const std::vector<MockPoint>& points,
 
 TEST(RangeTree2dTest, RangeSearchTest) {
   const int64_t n = 1000;
-  const int64_t cap = 1024;
   const float l = -20.0;
   const float r = 20.0;
   std::vector<MockPoint> points = MakeRandomPoinst(n, l, r);
 
   RangeTree2d tree(points);
   ASSERT_EQ(tree.size(), n);
-  ASSERT_EQ(tree.capacity(), cap);
 
   const AABB aabb1(-10.0, -10.0, 10.0, 10.0);
   std::vector<const MockPoint*> ret = tree.RangeSearch<MockPoint>(aabb1);


### PR DESCRIPTION
This PR improve the space usage of RangeTree2d. The outer tree of RangeTree2d is a non-recursive segment tree. Previously we padded the segment tree size to 2^n. Since there is no binary search operation on the tree, so there is no need to do this padding.